### PR TITLE
Add SYMBOLS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Set next env variables:
 - `ACCESS_KEY` and `SECRET_KEY` from your Huobi account
 - `TELEGRAM_API_TOKEN` - telegram bot API token
 - `TELEGRAM_USER_ID` - telegram notifications reciver user id
+optional env variables:
+- `SYMBOLS` - list of tracked symbols. Example: `btcusdt,ethusdt`.
 
 # Heroku deployment
 Create app and add next buildpacks:

--- a/main.py
+++ b/main.py
@@ -77,13 +77,17 @@ def subscribe():
     """
     Subscribe to spot order events 
     """
-
-    from huobi.client.generic import GenericClient
-    generic_client = GenericClient()
-    symbols = ','.join([list_obj.symbol for list_obj in generic_client.get_exchange_symbols()])
+    
+    symbols = os.environ.get('SYMBOLS')
+    if not symbols:
+        print('[WARNING] SYMBOLS env variable not found. All symbols will be tracked. Operation in this mode may not be stable.\n\
+            https://github.com/kuznetsov-m/huobi-spot-order-notification/issues/2'
+        )
+        from huobi.client.generic import GenericClient
+        generic_client = GenericClient()
+        symbols = ','.join([list_obj.symbol for list_obj in generic_client.get_exchange_symbols()])
+    print(f'Tracked symbols: {symbols}')
     trade_client.sub_order_update(symbols=symbols, callback=callback)
-
-    print('subscribed')
 
 if __name__ == "__main__":
     telegram_bot.send_text(TELEGRAM_USER_ID, 'Bot restarted')


### PR DESCRIPTION
As a solution to the https://github.com/kuznetsov-m/huobi-spot-order-notification/issues/2, the ability to specify a list of tracked symbols via the SYMBOLS env variable has been added.
When specifying one symbol (example: "ethusdt"), the bot's work is stable.